### PR TITLE
add cgroup support via systemd-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This is the full list of values from docker's
 [`config.json`](https://github.com/opencontainers/image-spec/blob/main/config.md)
 that are actually used by `d-run`:
 
+-	`User`
 -	`Hostname`
 -	`WorkingDir`
 -	`Env`
@@ -22,7 +23,6 @@ that are actually used by `d-run`:
 `d-run` uses the following additional values:
 
 -	`net` (bool) - enable networking (default: false)
--	`fakeroot` (bool) - map UID and GID to 0 (default: false)
 -	`rw` (bool) - allow to modify the base image (default: false)
 
 You are encouraged to modify this file, e.g. to add a volume or change the

--- a/d-run
+++ b/d-run
@@ -42,7 +42,7 @@ def parse_user(user):
 	return uid, gid
 
 
-def build_cmd(dir, config):
+def build_bwrap(dir, config):
 	cmd = [
 		'bwrap',
 		'--bind', os.path.join(dir, 'rootfs'), '/',
@@ -88,6 +88,24 @@ def build_cmd(dir, config):
 	cmd += config['Cmd']
 
 	return cmd
+
+
+def build_cmd(dir, config):
+	cmd = [
+		'systemd-run',
+		'--user',
+		'--scope',
+		'--quiet',
+	]
+
+	if config.get('CpuShares'):
+		cmd += ['-p', f'CPUWeight={config["CpuShares"]}']
+	if config.get('Memory'):
+		cmd += ['-p', f'MemoryMax={config["Memory"]}']
+	if config.get('MemorySwap'):
+		cmd += ['-p', f'MemorySwapMax={config["MemorySwap"]}']
+
+	return cmd + build_bwrap(dir, config)
 
 
 def parse_args():

--- a/d-run
+++ b/d-run
@@ -3,6 +3,8 @@
 import os
 import json
 import argparse
+import grp
+import pwd
 
 
 def make_volume(path, dir):
@@ -23,6 +25,21 @@ def make_volume(path, dir):
 	op = '--ro-bind' if mode == 'ro' else '--bind'
 
 	return [op, hostpath, path]
+
+
+def parse_user(user):
+	uid = user
+	gid = None
+
+	if ':' in user:
+		uid, gid = uid.split(':', 1)
+		if not gid.isdigit():
+			gid = grp.getgrnam(gid).gr_gid
+
+	if not uid.isdigit():
+		uid = pwd.getpwnam('tobias').pw_uid
+
+	return uid, gid
 
 
 def build_cmd(dir, config):
@@ -59,11 +76,11 @@ def build_cmd(dir, config):
 	if not config.get('rw'):
 		cmd += ['--remount-ro', '/']
 
-	if config.get('fakeroot'):
-		cmd += [
-			'--uid', '0',
-			'--gid', '0',
-		]
+	if config.get('User'):
+		uid, gid = parse_user(config['User'])
+		cmd += ['--uid', uid]
+		if gid is not None:
+			cmd += ['--gid', gid]
 
 	if config.get('Entrypoint'):
 		cmd += config['Entrypoint']
@@ -77,8 +94,8 @@ def parse_args():
 	parser = argparse.ArgumentParser()
 	parser.add_argument('dir')
 	parser.add_argument('-v', '--volume', action='append')
+	parser.add_argument('-u', '--user')
 	parser.add_argument('-n', '--net', action='store_true')
-	parser.add_argument('-r', '--fakeroot', action='store_true')
 	parser.add_argument('-w', '--rw', action='store_true')
 	parser.add_argument('cmd', nargs='*')
 	return parser.parse_args()
@@ -96,8 +113,8 @@ if __name__ == '__main__':
 		config['net'] = True
 	if args.rw:
 		config['rw'] = True
-	if args.fakeroot:
-		config['fakeroot'] = True
+	if args.user:
+		config['User'] = args.user
 	if args.volume:
 		if not config.get('Volumes'):
 			config['Volumes'] = {}


### PR DESCRIPTION
So far, d-run concentrates on namespaces. However, there are more building blocks to containers. An important one is cgroups.

Cgroups (control groups) allow to set resource limits for processes. The cgroup of a process can be found by looking into `/proc/{pid}/cgroup`. They are managed via a special file system in `/srs/fs/cgroup/` ([spec](https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html)). A cgroup is created by creating a folder in that subtree. Resource limits are set by writing to files in that folder. Cgroups can also be hierarchical. Who is allowed to create cgroups depends on the settings of the parent. On the root of the tree, only the root user can create cgroups.

Systemd uses cgroups extensively. It creates a cgroup under `/sys/fs/cgroup/user.slice/user-1000.slice/user@1000.service/` where user 1000 can create new cgroups. It also provides the [systemd-run](https://salsa.debian.org/systemd-team/systemd/-/blob/debian/master/src/run/run.c) command that allows to create a cgroup with some properties, run a command in that cgroup, and then remove the cgroup again. As far as I understand, `systemd-run --scope` will communicate with the privileged systemd process to setup the cgroup, but will `exec` the container itself, so there is little chance of a privilege escalation. The available options for resource control are available at `man systemd.resource-control`.

The OCI container spec does not contain any metadata for resource control. However, it reserves some keywords that are used by the [docker spec](https://github.com/moby/moby/blob/v20.10.8/image/spec/v1.2.md#image-json-description). They are quite limited though (only `Memory`, `MemorySwap`, and `CpuShares`).

This pull request proposes to use `systemd-run` to implement support for the three config options defined by docker. This follows the principal "Use established tools for the complicated bits".

However, I am not convinced:

- This would add an established, but still huge dependency (systemd)
- The restrictions defined by docker are not very granular. OCI doesn't even have resource limits. so I am not sure how useful this really is.
- I am not completely sure whether limiting CPU access is even possible for unprivileged users (the [arch wiki](https://wiki.archlinux.org/title/Cgroups#Controller_types) talks about "delegation").
- I do not have a practical usecase right now.